### PR TITLE
Add CompanionAPI

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,12 +1,255 @@
 {
   "pins" : [
     {
+      "identity" : "async-http-client",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/async-http-client.git",
+      "state" : {
+        "revision" : "291438696abdd48d2a83b52465c176efbd94512b",
+        "version" : "1.20.1"
+      }
+    },
+    {
+      "identity" : "async-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/async-kit.git",
+      "state" : {
+        "revision" : "7ece208cd401687641c88367a00e3ea2b04311f1",
+        "version" : "1.19.0"
+      }
+    },
+    {
+      "identity" : "console-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/console-kit.git",
+      "state" : {
+        "revision" : "a31f44ebfbd15a2cc0fda705279676773ac16355",
+        "version" : "4.14.1"
+      }
+    },
+    {
+      "identity" : "multipart-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/multipart-kit.git",
+      "state" : {
+        "revision" : "12ee56f25bd3fc4c2d09c2aa16e69de61dc786e8",
+        "version" : "4.6.0"
+      }
+    },
+    {
+      "identity" : "openapikit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattpolzin/OpenAPIKit",
+      "state" : {
+        "revision" : "33a9984b4af03f00e68b8ee85f1273cb826af04f",
+        "version" : "3.1.3"
+      }
+    },
+    {
+      "identity" : "routing-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/routing-kit.git",
+      "state" : {
+        "revision" : "2a92a7eac411a82fb3a03731be5e76773ebe1b3e",
+        "version" : "4.9.0"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms",
+      "state" : {
+        "revision" : "f6919dfc309e7f1b56224378b11e28bab5bccc42",
+        "version" : "1.2.0"
+      }
+    },
+    {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
         "revision" : "46989693916f56d1186bd59ac15124caef896560",
         "version" : "1.3.1"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "cd142fd2f64be2100422d658e7411e39489da985",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "94cf62b3ba8d4bed62680a282d4c25f9c63c2efb",
+        "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "f0525da24dc3c6cbb2b6b338b65042bc91cbc4bb",
+        "version" : "3.3.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types",
+      "state" : {
+        "revision" : "12358d55a3824bd5fed310b999ea8cf83a9a1a65",
+        "version" : "1.0.3"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "e97a6fcb1ab07462881ac165fdbb37f067e205d5",
+        "version" : "1.5.4"
+      }
+    },
+    {
+      "identity" : "swift-metrics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-metrics.git",
+      "state" : {
+        "revision" : "971ba26378ab69c43737ee7ba967a896cb74c0d1",
+        "version" : "2.4.1"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "fc63f0cf4e55a4597407a9fc95b16a2bc44b4982",
+        "version" : "2.64.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "a3b640d7dc567225db7c94386a6e71aded1bfa63",
+        "version" : "1.22.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "0904bf0feb5122b7e5c3f15db7df0eabe623dd87",
+        "version" : "1.30.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "7c381eb6083542b124a6c18fae742f55001dc2b5",
+        "version" : "2.26.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "6cbe0ed2b394f21ab0d46b9f0c50c6be964968ce",
+        "version" : "1.20.1"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "0a5bc04095a675662cf24757cc0640aa2204253b",
+        "version" : "1.0.2"
+      }
+    },
+    {
+      "identity" : "swift-openapi-async-http-client",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-openapi-async-http-client",
+      "state" : {
+        "revision" : "abfe558a66992ef1e896a577010f957915f30591",
+        "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "swift-openapi-generator",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-openapi-generator",
+      "state" : {
+        "revision" : "7992d77065f2787e7651cf6d9be9b99ad38f5166",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-openapi-runtime",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-openapi-runtime",
+      "state" : {
+        "revision" : "76951d77a0609599d2dc233e7e40808a74767c6a",
+        "version" : "1.3.2"
+      }
+    },
+    {
+      "identity" : "swift-openapi-vapor",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-openapi-vapor",
+      "state" : {
+        "revision" : "3d7a840c344358ddf9b71ec21421f65cee461a5d",
+        "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "025bcb1165deab2e20d4eaba79967ce73013f496",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "vapor",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/vapor",
+      "state" : {
+        "revision" : "11cdb29614a5c7f8c5289f3c97b3398c3d89b395",
+        "version" : "4.92.5"
+      }
+    },
+    {
+      "identity" : "websocket-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/websocket-kit.git",
+      "state" : {
+        "revision" : "4232d34efa49f633ba61afde365d3896fc7f8740",
+        "version" : "2.15.0"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams",
+      "state" : {
+        "revision" : "8a835d918245ca22f36663dd3862138805d7f707",
+        "version" : "5.1.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -15,9 +15,12 @@ let package = Package(
         .executableTarget(
             name: "mdb",
             dependencies: [
+                "MDBServer",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ]
         ),
         .testTarget(name: "mdbTests", dependencies: ["mdb"]),
+        .target(name: "MDBServer"),
+        .testTarget(name: "MDBServerTests"),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -7,9 +7,17 @@ let package = Package(
     platforms: [.macOS(.v13)],
     products: [
         .executable(name: "mdb", targets: ["mdb"]),
+        .library(name: "CompanionClient", targets: ["CompanionClient"]),
+        .library(name: "CompanionServer", targets: ["CompanionServer"]),
+        .library(name: "MDBServer", targets: ["MDBServer"]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
+        .package(url: "https://github.com/apple/swift-openapi-generator", from: "1.2.1"),
+        .package(url: "https://github.com/apple/swift-openapi-runtime", from: "1.3.2"),
+        .package(url: "https://github.com/swift-server/swift-openapi-async-http-client", from: "1.0.0"),
+        .package(url: "https://github.com/swift-server/swift-openapi-vapor", from: "1.0.0"),
+        .package(url: "https://github.com/vapor/vapor", from: "4.92.5"),
     ],
     targets: [
         .executableTarget(
@@ -17,10 +25,41 @@ let package = Package(
             dependencies: [
                 "MDBServer",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                .product(name: "OpenAPIAsyncHTTPClient", package: "swift-openapi-async-http-client"),
             ]
         ),
         .testTarget(name: "mdbTests", dependencies: ["mdb"]),
-        .target(name: "MDBServer"),
-        .testTarget(name: "MDBServerTests"),
+        .target(
+            name: "CompanionClient",
+            dependencies: [
+                .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime"),
+            ],
+            path: "Sources/CompanionAPI",
+            exclude: ["Server"],
+            plugins: [
+                .plugin(name: "OpenAPIGenerator", package: "swift-openapi-generator"),
+            ]
+        ),
+        .target(
+            name: "CompanionServer",
+            dependencies: [
+                .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime"),
+            ],
+            path: "Sources/CompanionAPI",
+            exclude: ["Client"],
+            plugins: [
+                .plugin(name: "OpenAPIGenerator", package: "swift-openapi-generator"),
+            ]
+        ),
+        .testTarget(name: "CompanionAPITests", dependencies: ["CompanionClient", "CompanionServer"]),
+        .target(
+            name: "MDBServer",
+            dependencies: [
+                "CompanionServer",
+                .product(name: "OpenAPIVapor", package: "swift-openapi-vapor"),
+                .product(name: "Vapor", package: "vapor"),
+            ]
+        ),
+        .testTarget(name: "MDBServerTests", dependencies: ["MDBServer"]),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -36,6 +36,7 @@ let package = Package(
             ],
             path: "Sources/CompanionAPI",
             exclude: ["Server"],
+            resources: [.copy("openapi.yaml"), .copy("Client/openapi-generator-config.yaml")],
             plugins: [
                 .plugin(name: "OpenAPIGenerator", package: "swift-openapi-generator"),
             ]
@@ -47,6 +48,7 @@ let package = Package(
             ],
             path: "Sources/CompanionAPI",
             exclude: ["Client"],
+            resources: [.copy("openapi.yaml"), .copy("Server/openapi-generator-config.yaml")],
             plugins: [
                 .plugin(name: "OpenAPIGenerator", package: "swift-openapi-generator"),
             ]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/obj-p/mdb/actions/workflows/ci.yml/badge.svg)](https://github.com/obj-p/mdb/actions/workflows/ci.yml/badge.svg)
 [![Codecov](https://codecov.io/gh/obj-p/mdb/graphs/badge.svg)](https://codecov.io/gh/obj-p/mdb)
-[![Swift](https://img.shields.io/badge/Swift-5.9_5.10-orange?style=flat-square)](https://img.shields.io/badge/Swift-5.9_5.10-Orange?style=flat-square)
+[![Swift](https://img.shields.io/badge/Swift-5.10_5.9-orange?style=flat-square)](https://img.shields.io/badge/Swift-5.10_5.9-Orange?style=flat-square)
 [![Platforms](https://img.shields.io/badge/Platforms-macOS_iOS-yellowgreen?style=flat-square)](https://img.shields.io/badge/Platforms-macOS_iOS-Green?style=flat-square)
 
 Development is underway 🚧. Stay tuned for the initial release 📺.

--- a/Sources/CompanionAPI/Client/CompanionClient.swift
+++ b/Sources/CompanionAPI/Client/CompanionClient.swift
@@ -1,0 +1,1 @@
+import Foundation

--- a/Sources/CompanionAPI/Client/openapi-generator-config.yaml
+++ b/Sources/CompanionAPI/Client/openapi-generator-config.yaml
@@ -1,0 +1,4 @@
+accessModifier: public
+generate:
+  - client
+  - types

--- a/Sources/CompanionAPI/Server/CompanionServiceImpl.swift
+++ b/Sources/CompanionAPI/Server/CompanionServiceImpl.swift
@@ -1,0 +1,9 @@
+import OpenAPIRuntime
+
+public struct CompanionServiceImpl: APIProtocol {
+    public init() {}
+
+    public func getDevices(_: Operations.getDevices.Input) async throws -> Operations.getDevices.Output {
+        .ok(.init(body: .json(.init(devices: []))))
+    }
+}

--- a/Sources/CompanionAPI/Server/openapi-generator-config.yaml
+++ b/Sources/CompanionAPI/Server/openapi-generator-config.yaml
@@ -1,0 +1,4 @@
+accessModifier: public
+generate:
+  - server
+  - types

--- a/Sources/CompanionAPI/openapi.yaml
+++ b/Sources/CompanionAPI/openapi.yaml
@@ -3,7 +3,7 @@ info:
   title: CompanionService
   version: 1.0.0
 servers:
-  - url: /
+  - url: /api
 paths:
   /devices:
     get:

--- a/Sources/CompanionAPI/openapi.yaml
+++ b/Sources/CompanionAPI/openapi.yaml
@@ -1,0 +1,29 @@
+openapi: '3.1.0'
+info:
+  title: CompanionService
+  version: 1.0.0
+servers:
+  - url: /
+paths:
+  /devices:
+    get:
+      operationId: getDevices
+      responses:
+        '200':
+          description: A list of available devices.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Devices'
+
+components:
+  schemas:
+    Devices:
+      type: object
+      properties:
+        devices:
+          type: array
+          items:
+            type: string
+      required:
+        - devices

--- a/Sources/MDBServer/MDBServer.swift
+++ b/Sources/MDBServer/MDBServer.swift
@@ -1,0 +1,1 @@
+import Foundation

--- a/Sources/MDBServer/MDBServer.swift
+++ b/Sources/MDBServer/MDBServer.swift
@@ -6,12 +6,14 @@ public extension Application {
     static func companionServiceApp() throws -> Application {
         let environment = Environment(
             name: "development",
+            // Only pass the path through to Vapor's environment. This avoids passing mdb's arguments through.
             arguments: [ProcessInfo.processInfo.arguments[0]]
         )
+
         let app = Application(environment)
         let transport = VaporTransport(routesBuilder: app)
         let handler = CompanionServiceImpl()
-        try handler.registerHandlers(on: transport)
+        try handler.registerHandlers(on: transport, serverURL: CompanionServer.Servers.server1())
         return app
     }
 }

--- a/Sources/MDBServer/MDBServer.swift
+++ b/Sources/MDBServer/MDBServer.swift
@@ -1,1 +1,17 @@
-import Foundation
+import CompanionServer
+import OpenAPIVapor
+import Vapor
+
+public extension Application {
+    static func companionServiceApp() throws -> Application {
+        let environment = Environment(
+            name: "development",
+            arguments: [ProcessInfo.processInfo.arguments[0]]
+        )
+        let app = Application(environment)
+        let transport = VaporTransport(routesBuilder: app)
+        let handler = CompanionServiceImpl()
+        try handler.registerHandlers(on: transport)
+        return app
+    }
+}

--- a/Sources/mdb/Commands/StartServer.swift
+++ b/Sources/mdb/Commands/StartServer.swift
@@ -1,10 +1,15 @@
 import ArgumentParser
+import MDBServer
+import Vapor
 
-struct StartServer: ParsableCommand {
+struct StartServer: AsyncParsableCommand {
     static let configuration = CommandConfiguration(commandName: "start-server")
 
     @OptionGroup(visibility: .hidden)
     var globalOptions: GlobalOptions
 
-    func run() throws {}
+    func run() async throws {
+        let app = try Application.companionServiceApp()
+        try await app.execute()
+    }
 }

--- a/Sources/mdb/MDB.swift
+++ b/Sources/mdb/MDB.swift
@@ -2,7 +2,7 @@ import ArgumentParser
 import Foundation
 
 @main
-struct MDB: ParsableCommand {
+struct MDB: AsyncParsableCommand {
     static let configuration = CommandConfiguration(subcommands: [StartServer.self])
 
     @OptionGroup()

--- a/Tests/CompanionAPITests/CompanionServerTests.swift
+++ b/Tests/CompanionAPITests/CompanionServerTests.swift
@@ -1,0 +1,1 @@
+import Foundation

--- a/Tests/MDBServerTests/MDBServerTests.swift
+++ b/Tests/MDBServerTests/MDBServerTests.swift
@@ -1,0 +1,1 @@
+import Foundation


### PR DESCRIPTION
The goal of this PR is to add a MDBAPI client and server implementation that may be spun up using `mdb -p 5037 start-server`.

## TODO

- [ ] How should third party plugins interact with the server?
  - Should there be a `mdb-server` CLI to start the server independent of `mdb`?
- [ ] ~JSONRPC server implementation. Could be room to establish a JSON schema to codegen a JSON RPC toolkit. Available open source is quite sparse.~ No longer using JSON RPC
- [ ] https://docs.codecov.com/docs/commit-status

## Reference

- https://swiftpackageindex.com/apple/swift-openapi-generator/1.2.1/tutorials/swift-openapi-generator
- https://github.com/apple/swift-openapi-generator
- [swift-package-manager](https://github.com/apple/swift-package-manager) as an ArgumentParser example
- [vapor](https://docs.vapor.codes) for inspiration on the server implementation
- https://github.com/apple/swift-argument-parser/issues/254
- https://github.com/apple/swift-argument-parser/issues/266
- https://github.com/apple/swift-argument-parser/issues/267
- https://developer.android.com/tools/adb
- https://github.com/amzn/smoke-framework
- https://forums.swift.org/t/how-can-i-encode-a-struct-to-data-binary/68652
- https://stackoverflow.com/questions/3634041/detect-when-android-emulator-is-fully-booted
- https://spec.openapis.org/oas/v3.1.0#server-object
- https://www.asyncapi.com/en
- https://iphonedev.wiki/Reverse_Engineering_Tools
- https://aws.amazon.com/blogs/compute/building-amazon-machine-images-amis-for-ec2-mac-instances-with-packer/
- https://socket.io/docs/v4/using-multiple-nodes/

### EDIT Fri Mar 29

Decided against JSON RPC in favor of REST, websocket, openapi stack. No longer using the following references:

<details><summary>JSON RPC resources. Minimized due as it's no longer being considered.</summary>

- [sourcekit-lsp](https://github.com/apple/sourcekit-lsp) a JSONRPC server implementation
- JSON RPC
  - [JsonRPC](https://github.com/tesseract-one/JsonRPC.swift)
  - [JSONRPC](https://github.com/ChimeHQ/JSONRPC)
  - [JSONRPCKit](https://github.com/bricklife/JSONRPCKit)
  - [JRPCSwiftNio](https://github.com/voynovia/JRPCSwiftNio)
  - [SwiftJSONRPC](https://github.com/kolyasev/SwiftJSONRPC)
  - [dotSwift 2019 - Tom Doron - Implementing JSON-RPC with SwiftNIO](https://www.youtube.com/watch?v=Rlhlc6NaO4w)
- https://www.jsonrpc.org
- https://open-rpc.org

```
lsof -c sourcekit-lsp
echo -n "foo" > /dev/ttys004
```

- https://code.visualstudio.com/api/language-extensions/language-server-extension-guide
- https://github.com/microsoft/vscode-extension-samples/blob/main/lsp-multi-server-sample/client/src/extension.ts
- https://github.com/swift-server/vscode-swift
- https://learn.microsoft.com/en-us/visualstudio/extensibility/adding-an-lsp-extension?view=vs-2022

[Ask HN: Why isn't JSON-RPC more widely adopted?](https://news.ycombinator.com/item?id=34211796)

</details>